### PR TITLE
Add EmmyLua annotations for Material component

### DIFF
--- a/Data Files/MWSE/mods/CraftingFramework/components/Material.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/components/Material.lua
@@ -1,5 +1,6 @@
 local Util = require("CraftingFramework.util.Util")
 local logger = Util.createLogger("Material")
+---@class Material
 local Material = {
     schema = {
         name = "Material",
@@ -12,6 +13,8 @@ local Material = {
 }
 
 Material.registeredMaterials = {}
+---@param id string
+---@return craftingFrameworkMaterial material
 function Material.getMaterial(id)
     local material = Material.registeredMaterials[id:lower()]
     if not material then
@@ -34,6 +37,8 @@ function Material.getMaterial(id)
     return material
 end
 
+---@param data craftingFrameworkMaterialData
+---@return craftingFrameworkMaterial material
 function Material:new(data)
     Util.validate(data, Material.schema)
 

--- a/Data Files/MWSE/mods/CraftingFramework/types/Material.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/Material.lua
@@ -1,0 +1,51 @@
+---@meta
+
+---@class craftingFrameworkMaterialData
+---@field id string **Required.**  This will be the unique identifier used internally by Crafting Framework to identify this `material`.
+---@field name string The name of the material. Used in various UIs.
+---@field ids table<number, string> **Required.**  This is the list of item ids that are considered as identical material.
+
+---@class craftingFrameworkMaterialRequirement
+---@field material string **Required.** The Crafting Framework id to indentify the material.
+---@field count number *Default*: `0`. The required amount of the material.
+
+---@class craftingFrameworkMaterial
+---@field id string The material's id. This is the id used as the material's unique identifer within Crafting Framework.
+---@field name string The material's name. Used in various UIs.
+---@field ids table<string, boolean> This is the list of item ids that are considered as identical material.
+craftingFrameworkMaterial = {}
+
+---This method returns `true` if the `itemId` is registered as a this material.
+---@param itemId string The id of the item to check.
+---@return boolean isMaterial True if the item of provided `id` is in this material's list of ids.
+function craftingFrameworkMaterial:itemIsMaterial(itemId) end
+
+---This method returns the name of the material.
+---@return string name
+function craftingFrameworkMaterial:getName() end
+
+---This method returns `true` if the player has at least `numRequired` instances of this material in their inventory.
+---@param numRequired number
+---@return boolean hasEnough
+function craftingFrameworkMaterial:checkHasIngredient(numRequired) end
+
+
+---@class Material
+---@field registeredMaterials table<string, craftingFrameworkMaterial>
+Material = {}
+
+--- If the material of provided `id` hasn't been registered before, but `id` is a valid item id (e.g. defined in the Construction Set), a new material will be created.
+---@param id string The material's unique identifier.
+---@return craftingFrameworkMaterial material The material requested.
+function Material.getMaterial(id) end
+
+---This method creates a new material.
+---@param data craftingFrameworkMaterialData This table accepts following values:
+---
+--- `id`: string — **Required.**  This will be the unique identifier used internally by Crafting Framework to identify this `material`.
+---
+--- `name`: string — The name of the material. Used in various UIs.
+---
+--- `ids`: table<number, string> — **Required.**  This is the list of item ids that are considered as identical material.
+---@return craftingFrameworkMaterial material The newly constructed material.
+function Material:new(data) end


### PR DESCRIPTION
I decided to split the annotations, so there is base class Material, and craftingFrameworkMaterial type for the children of Material. I added EmmyLua annotations for the methods/fields that are supposed to be accessed from the child classes. That way we won't get `myMaterial.getMaterial("someId")` in the autocomplete suggestions. On the base Material class I only added EmmyLua annotations for the fields, functions and methods that are actually supposed to be used on the base class, not on the children, for the same reason as above.