### PR TITLE
Add EmmyLua annotations for MenuButton

### DIFF
--- a/Data Files/MWSE/mods/CraftingFramework/components/Craftable.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/components/Craftable.lua
@@ -178,7 +178,10 @@ function Craftable:getDescription()
     return self.description
 end
 
+---@param reference tes3reference
+---@return craftingFrameworkMenuButtonData[] menuButtons
 function Craftable:getMenuButtons(reference)
+	---@type craftingFrameworkMenuButtonData[]
     local menuButtons = {}
     if self.additionalMenuOptions then
         for _, option in ipairs(self.additionalMenuOptions) do
@@ -192,6 +195,7 @@ function Craftable:getMenuButtons(reference)
             })
         end
     end
+	---@type craftingFrameworkMenuButtonData[]
     local defaultButtons = {
         {
             text = "Open",

--- a/Data Files/MWSE/mods/CraftingFramework/types/Craftable.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/Craftable.lua
@@ -47,7 +47,7 @@ function craftingFrameworkCraftable:swap(reference) end
 
 ---comment
 ---@param reference tes3reference
----@return table menuButtons
+---@return craftingFrameworkMenuButtonData[] menuButtons
 function craftingFrameworkCraftable:getMenuButtons(reference) end
 
 ---comment

--- a/Data Files/MWSE/mods/CraftingFramework/types/MenuButton.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/MenuButton.lua
@@ -1,0 +1,13 @@
+---@meta
+
+---@class craftingFrameworkTooltipData
+---@field header string|fun(): string The header text for the tooltip or a function that returns one.
+---@field text string The description text of the tooltip.
+
+---@class craftingFrameworkMenuButtonData
+---@field text string **Required.** The text on the button.
+---@field callback function This function is called after the associated button is created.
+---@field tooltip craftingFrameworkTooltipData This is the tooltip shown when the button is enabled.
+---@field tooltipDisabled craftingFrameworkTooltipData This tooltip is shown when the button is disabled.
+---@field enableRequirements fun(): boolean If this function returns `flase`, the associated button will be disabled.
+---@field showRequirements fun(): boolean If this function returns `false`, the associated button will not be created.

--- a/Data Files/MWSE/mods/CraftingFramework/util/messageBox.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/util/messageBox.lua
@@ -1,6 +1,7 @@
 local MenuButton = require("CraftingFramework.components.MenuButton")
 local validator = require("CraftingFramework.util.validator")
 --Generic Tooltip with header and description
+---@param e craftingFrameworkTooltipData
 local function createTooltip(e)
     if type(e) == "function" then
         e = e()
@@ -37,6 +38,7 @@ local function createTooltip(e)
     tooltip:updateLayout()
 end
 
+---@param e { buttons : craftingFrameworkMenuButtonData[], bottonsBlock : tes3uiElement, menu : tes3uiElement, startIndex : number, endIndex : number, callbackParams : table }
 local function populateButtons(e)
     local buttons = e.buttons
     local buttonsBlock = e.buttonsBlock


### PR DESCRIPTION
In this PR, I also added updated the sites where those are used, namely: `Craftable:getMenuButtons`, `createTooltip`, and `populateButtons`.