### PR TITLE
Improved Tool and ToolRequirement annotations

### DIFF
--- a/Data Files/MWSE/mods/CraftingFramework/components/Tool.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/components/Tool.lua
@@ -17,7 +17,7 @@ local Tool = {
 
 Tool.registeredTools = {}
 ---@param id string
----@return craftingFrameworkTool Tool
+---@return craftingFrameworkTool tool
 function Tool.getTool(id)
     return Tool.registeredTools[id]
 end
@@ -83,7 +83,7 @@ function Tool:use(amount)
     log:debug("Couldn't find any item to degrade")
 end
 
----@return table<string, boolean>
+---@return table<string, true>
 function Tool:getToolIds()
     if self.ids and #self.ids > 0 then return self.ids end
     if self.requirement then

--- a/Data Files/MWSE/mods/CraftingFramework/components/ToolRequirement.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/components/ToolRequirement.lua
@@ -18,7 +18,7 @@ local ToolRequirement = {
 
 --Constructor
 ---@param data craftingFrameworkToolRequirementData
----@return craftingFrameworkTool
+---@return craftingFrameworkToolRequirement toolRequirement
 function ToolRequirement:new(data)
     Util.validate(data, ToolRequirement.schema)
     data.tool = Tool.getTool(data.tool)

--- a/Data Files/MWSE/mods/CraftingFramework/types/Craftable.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/Craftable.lua
@@ -34,7 +34,7 @@
 ---@field additionalMenuOptions table A list of additional menu options that will be displayed in the craftable menu
 ---@field soundId string Provide a sound ID (for a sound registered in the CS) that will be played when the craftable is crafted
 ---@field soundPath string Provide a custom sound path that will be played when an craftable is crafted
----@field soundType craftingFrameworkCraftableSoundType Determines the crafting sound used, using sounds from the framework or added by interop. These include: "fabric", "wood", "leather", "rope", "straw" and "metal"
+---@field soundType craftingFrameworkCraftableSoundType Determines the crafting sound used, using sounds from the framework or added by interop. These include: "fabric", "wood", "leather", "rope", "straw", "metal" and "carve."
 ---@field materialRecovery number The percentage of materials used to craft the item that will be recovered. Overrides the default amount set in the Crafting Framework MCM
 ---@field maxSteepness number The max angle a crafted object will be oriented to while repositioning
 ---@field resultAmount number The amount of the item to be crafted

--- a/Data Files/MWSE/mods/CraftingFramework/types/Craftable.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/Craftable.lua
@@ -7,6 +7,7 @@
 ---| '"rope"'
 ---| '"straw"'
 ---| '"metal"'
+---| '"carve"'
 
 ---@class craftingFrameworkCraftableData
 ---@field id string **Required.**

--- a/Data Files/MWSE/mods/CraftingFramework/types/Tool.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/Tool.lua
@@ -1,21 +1,30 @@
 ---@meta
 
+-- This is selfish occupation of the global EmmyLua types namespace. It's used in type annotation
+-- for standard lookup tables table<string, true> (e.g. `[myToolId] = true,`). This won't be needed
+-- once we can use Sumneko's Lua extension v3.x, since in v3.x `true` will be recognized as a valid
+-- type. Then this alias can be removed.
+
+---@alias true "true"
+
 ---@class craftingFrameworkToolData
 ---Data used to construct a new Tool
 ---@field id string **Required.**  This will be the unique identifier used internally by Crafting Framework to identify this `tool`.
 ---@field name string The name of the tool. Used in various UIs.
 ---@field ids table<number, string> **Required.**  This is the list of item ids that are considered identical tool.
----@field requirement function Custom requirements for whether an item in the player's inventory counts as this tool.
+---@field requirement fun(stack : tes3itemStack): boolean Optionally, you can provide a function that will be used to evaluate if a certain item in the player's inventory can be used as a tool. It will be called with a `tes3itemStack` parameter, that it needs to evaluate if it should be recognized as a tool. When that is the case the function needs to return `true`, `false` otherwise. Used when no `ids` are provided.
 
 ---@class craftingFrameworkTool
 ---A tool is an item that is required for crafting an item, but not consumed during crafting like a material. It may need to be equipped, and can be confugured to lose durability each time it is used for crafting.
 ---@field id string The tool's id. This is the id used as the tool's unique identifer within Crafting Framework. It shouldn't be confused with item ids defined in the Construction Set.
 ---@field name string The tool's name.
----@field ids table<number, string> A table with the in-game ids of the items that are registered as this tool.
+---@field ids table<string, true> A standard lookup table with the in-game ids of the items that are registered as this tool.
+---@field requirement fun(stack : tes3itemStack): boolean Optionally, you can provide a function that will be used to evaluate if a certain item in the player's inventory can be used as a tool. When that is the case the function needs to return `true`, `false` otherwise. Used when no `ids` are provided.
+---@field registeredTools table<string, craftingFrameworkTool>
 craftingFrameworkTool = {}
 
 ---@param id string The tool's unique identifier.
----@return craftingFrameworkTool Tool The tool requested.
+---@return craftingFrameworkTool tool The tool requested.
 function craftingFrameworkTool.getTool(id) end
 
 ---This method creates a new tool.
@@ -26,6 +35,8 @@ function craftingFrameworkTool.getTool(id) end
 --- `name`: string — The name of the tool. Used in various UIs.
 ---
 --- `ids`: table<number, string> — **Required.**  This is the list of item ids that are considered identical tool.
+---
+--- `requirement`: fun(stack : tes3itemStack): boolean —  Optionally, you can provide a function that will be used to evaluate if a certain item in the player's inventory can be used as a tool. It will be called with a `tes3itemStack` parameter, that it needs to evaluate if it should be recognized as a tool. When that is the case the function needs to return `true`, `false` otherwise. Used when no `ids` are provided.
 ---@return craftingFrameworkTool Tool The newly constructed tool.
 function craftingFrameworkTool:new(data) end
 
@@ -38,9 +49,10 @@ function craftingFrameworkTool:getName() end
 function  craftingFrameworkTool:use(amount) end
 
 ---The method returns a list of valid tool ids.
----@return string[]
+---@return table<string, true>
 function craftingFrameworkTool:getToolIds() end
 
+---This method should return `true` when given `itemStack` can be used as a tool. Usually this method will be invoked for each item in the player's inventory when `tool:getToolIds()` is called.
 ---@param stack tes3itemStack
 ---@return boolean
 function craftingFrameworkTool:requirement(stack) end

--- a/Data Files/MWSE/mods/CraftingFramework/types/ToolRequirement.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/ToolRequirement.lua
@@ -1,76 +1,44 @@
 ---@meta
 
 ---@class craftingFrameworkToolRequirementData
----@field tool string **Required.** The tool's id. This is the id used as the tool's unique identifer within Crafting Framework. It shouldn't be confused with item ids defined in the Construction Set.
+---@field tool string **Required.** The id of the required tool. This is the id used as the tool's unique identifer within Crafting Framework. It shouldn't be confused with item ids defined in the Construction Set.
 ---@field equipped boolean When `true`, the player needs to have the tool equipped to be considered valid.
----@field count number How many of the items need to be in the player's inventory.
+---@field count number How many instances of the tool need to be in the player's inventory.
 ---@field conditionPerUse number Tool's condition will be reduced by this value per use.
 
 
 ---@class craftingFrameworkToolRequirement
 ---A tool is an item that is required for crafting an item, but not consumed during crafting like a material. It may need to be equipped, and can be confugured to lose durability each time it is used for crafting.
----@field tool craftingFrameworkTool **Required.** The tool's id. This is the id used as the tool's unique identifer within Crafting Framework. It shouldn't be confused with item ids defined in the Construction Set.
+---@field tool craftingFrameworkTool The id of the required tool. This is the id used as the tool's unique identifer within Crafting Framework. It shouldn't be confused with item ids defined in the Construction Set.
 ---@field equipped boolean When `true`, the player needs to have the tool equipped to be considered valid.
----@field count number How many of the items need to be in the player's inventory.
+---@field count number How many instances of the tool need to be in the player's inventory.
 ---@field conditionPerUse number Tool's condition will be reduced by this value per use.
 craftingFrameworkToolRequirement = {}
 
----@param id string The tool's unique identifier.
----@return craftingFrameworkTool Tool The tool requested.
-function craftingFrameworkToolRequirement.getTool(id) end
-
----This method creates a new tool.
+---This method creates a new `toolRequirement` object.
 ---@param data craftingFrameworkToolRequirementData This table accepts following values:
 ---
---- `id`: string — **Required.**  This will be the unique identifier used internally by Crafting Framework to identify this `tool`.
+--- `tool`: string —  **Required.** The id of the required tool. This is the id used as the tool's unique identifer within Crafting Framework. It shouldn't be confused with item ids defined in the Construction Set.
 ---
---- `name`: string — The name of the tool. Used in various UIs.
+--- `equipped`: boolean —  When `true`, the player needs to have the tool equipped to be considered valid.
 ---
---- `ids`: table<number, string> — **Required.**  This is the list of item ids that are considered identical tool.
----@return craftingFrameworkToolRequirement Tool The newly constructed tool.
+--- `count`: number —  How many instances of the tool need to be in the player's inventory.
+---
+--- `conditionPerUse`: number —  Tool's condition will be reduced by this value per use.
+---@return craftingFrameworkToolRequirement toolRequirement The newly constructed toolRequirement.
 function craftingFrameworkToolRequirement:new(data) end
 
----This method returns the name of the tool.
----@return string name
-function craftingFrameworkToolRequirement:getName() end
-
----Find a valid tool of this type and apply condition damage if appropriate.
----@param amount number How much condition damage is done.
-function  craftingFrameworkToolRequirement:use(amount) end
-
----The method returns `true` if the player has the tool equipped.
----@param requirements craftingFrameworkToolRequirement This table accepts following values:
---- `tool`: string — **Required.** The tool's id.
----
---- `equipped`: boolean — When `true`, the player needs to have the tool equipped to be considered valid.
----
---- `count`: number — How many of the items need to be in the player's inventory.
----
---- `conditionPerUse`: number — Tool's condition will be reduced by this value per use.
----@return boolean
-function craftingFrameworkToolRequirement:hasToolEquipped(requirements) end
-
----The method returns `true` if the tool's condition is above zero.
----@param requirements craftingFrameworkToolRequirement This table accepts following values:
---- `tool`: string — **Required.** The tool's id.
----
---- `equipped`: boolean — When `true`, the player needs to have the tool equipped to be considered valid.
----
---- `count`: number — How many of the items need to be in the player's inventory.
----
---- `conditionPerUse`: number — Tool's condition will be reduced by this value per use.
----@return boolean
-function craftingFrameworkToolRequirement:hasToolCondition(requirements) end
+---@return nil
+function craftingFrameworkToolRequirement:getLabel() end
 
 ---The method returns `true` if the player has the tool that meets provided requirements.
----@param requirements craftingFrameworkToolRequirement This table accepts following values:
---- `tool`: string — **Required.** The tool's id.
----
---- `equipped`: boolean — When `true`, the player needs to have the tool equipped to be considered valid.
----
---- `count`: number — How many of the items need to be in the player's inventory.
----
---- `conditionPerUse`: number — Tool's condition will be reduced by this value per use.
 ---@return boolean
-function craftingFrameworkToolRequirement:hasTool(requirements) end
+function craftingFrameworkToolRequirement:hasTool() end
 
+---The method returns `true` if the player has the tool equipped.
+---@return boolean
+function craftingFrameworkToolRequirement:hasToolEquipped() end
+
+---The method returns `true` if the tool's condition is above zero.
+---@return boolean
+function craftingFrameworkToolRequirement:hasToolCondition() end


### PR DESCRIPTION
Summary of changes:

1. Fixed some leftover `craftingFrameworkTool` function/property instances in `craftingFrameworkToolRequirement` annotations that don't exist
2. Changed some descriptions to be more precise
3. Changed return type of Tool:getToolIDs from `---@return table<string, boolean>` to `---@return table<string, true>`
