### PR TITLE
Remove `---@alias true "true"`

### DIFF
--- a/Data Files/MWSE/mods/CraftingFramework/types/Tool.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/types/Tool.lua
@@ -1,12 +1,5 @@
 ---@meta
 
--- This is selfish occupation of the global EmmyLua types namespace. It's used in type annotation
--- for standard lookup tables table<string, true> (e.g. `[myToolId] = true,`). This won't be needed
--- once we can use Sumneko's Lua extension v3.x, since in v3.x `true` will be recognized as a valid
--- type. Then this alias can be removed.
-
----@alias true "true"
-
 ---@class craftingFrameworkToolData
 ---Data used to construct a new Tool
 ---@field id string **Required.**  This will be the unique identifier used internally by Crafting Framework to identify this `tool`.


### PR DESCRIPTION
Thanks to Null, we can now use the v3.x of the VSCode Lua extension. In those new versions, the `---@alias true "true"` is unnecessary, because `true` is now recognized as a real type for annotations' sake. This PR removes this workaround.