### PR TITLE
Correctly mark `interop.activatePositioner` params as optional

### DIFF
--- a/Data Files/MWSE/mods/CraftingFramework/interop.lua
+++ b/Data Files/MWSE/mods/CraftingFramework/interop.lua
@@ -103,9 +103,9 @@ end
 ]]
 ---@class CraftingFramework.interop.activatePositionerParams
 ---@field reference tes3reference
----@field pinToWall boolean
----@field placementSetting string
----@field blockToggle boolean
+---@field pinToWall? boolean
+---@field placementSetting? string
+---@field blockToggle? boolean
 
 ---@param e CraftingFramework.interop.activatePositionerParams
 function interop.activatePositioner(e)


### PR DESCRIPTION
These parameters weren't marked as optional, leading to warnings raised by LuaLS in the JOP code.